### PR TITLE
Introduce `useLongPress` hook with auto-dismiss and cleanup

### DIFF
--- a/src/components/UI/CarpetCardImage.tsx
+++ b/src/components/UI/CarpetCardImage.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef, useCallback } from 'react';
 import '../../Css/UI/ImageGrid.css';
 import { useNavigate, useLocation } from 'react-router';
+import { useLongPress } from '../../hooks/useLongPress';
 
 type CarpetCardImageProps = {
     imageUrl: string;
@@ -11,30 +11,13 @@ type CarpetCardImageProps = {
 export const CarpetCardImage = ({ imageUrl, carpetNum, altText }: CarpetCardImageProps) => {
     const navigate = useNavigate();
     const location = useLocation();
-    const [isPressed, setIsPressed] = useState(false);
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const { handlers, isPressed } = useLongPress(300, 3000);
 
     const handleClick = () => {
         navigate(`/carpet/${carpetNum}`, {
             state: { from: location.pathname + location.search }
         });
     };
-
-    const startLongPress = useCallback(() => {
-        timerRef.current = setTimeout(() => {
-            setIsPressed(true);
-            // Auto-dismiss the overlay after 3s so it doesn't stay stuck
-            resetTimerRef.current = setTimeout(() => setIsPressed(false), 4000);
-        }, 300);
-    }, []);
-
-    const cancelLongPress = useCallback(() => {
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-            timerRef.current = null;
-        }
-    }, []);
 
     return (
         <div className="carpet-card-image-container">
@@ -49,11 +32,7 @@ export const CarpetCardImage = ({ imageUrl, carpetNum, altText }: CarpetCardImag
                         handleClick();
                     }
                 }}
-                onTouchStart={(e) => { e.stopPropagation(); startLongPress(); }}
-                onTouchEnd={cancelLongPress}
-                onTouchCancel={cancelLongPress}
-                // Prevent "Save Image" / "Copy" OS popup during long-press on mobile
-                onContextMenu={(e) => e.preventDefault()}
+                {...handlers}
             >
                 <img
                     src={imageUrl}

--- a/src/components/UI/CarpetDetails.tsx
+++ b/src/components/UI/CarpetDetails.tsx
@@ -1,9 +1,10 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState } from 'react';
 import { CarpetDataTypeWithDate, deleteCarpet } from '../../lib/firebase/FireBaseCarpet.ts';
 import { Button, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import { IconButton } from '@mui/material';
 import '../../Css/UI/CarpetDetails.css';
+import { useLongPress } from '../../hooks/useLongPress';
 
 type CarpetDetailsProps = {
     carpet: CarpetDataTypeWithDate;
@@ -23,25 +24,8 @@ export const CarpetDetails = ({ carpet, onDeleted }: CarpetDetailsProps) => {
     const isFeet = carpet.unit === 'Feet';
     const unitLabel = isFeet ? 'ft' : 'm';
 
-    // Long-press state for mobile — reveals the delete icon button after a 500ms hold
-    const [isPressed, setIsPressed] = useState(false);
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const startLongPress = useCallback(() => {
-        timerRef.current = setTimeout(() => {
-            setIsPressed(true);
-            // Auto-dismiss after 3s so the button doesn't stay visible indefinitely
-            resetTimerRef.current = setTimeout(() => setIsPressed(false), 4000);
-        }, 300);
-    }, []);
-
-    const cancelLongPress = useCallback(() => {
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-            timerRef.current = null;
-        }
-    }, []);
+    // Long-press: after 300ms hold, reveals the delete icon button for 3s
+    const { handlers, isPressed } = useLongPress(300, 3000);
 
     const handleDeleteCarpetConfirm = async () => {
         setIsDeletingCarpet(true);
@@ -59,11 +43,7 @@ export const CarpetDetails = ({ carpet, onDeleted }: CarpetDetailsProps) => {
     return (
         <div
             className={`carpet-details-card${isPressed ? ' is-long-pressed' : ''}`}
-            onTouchStart={(e) => { e.stopPropagation(); startLongPress(); }}
-            onTouchEnd={cancelLongPress}
-            onTouchCancel={cancelLongPress}
-            // Prevent "Save Image" / "Copy" OS popup during long-press on mobile
-            onContextMenu={(e) => e.preventDefault()}
+            {...handlers}
         >
             <div className="searched-carpet-details-header">
                 <div className="detail-item">

--- a/src/components/UI/ImageGrid.tsx
+++ b/src/components/UI/ImageGrid.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import '../../Css/UI/ImageGrid.css';
 import { IconButton, Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions, Button } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
@@ -8,6 +8,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { deleteCarpetImage } from '../../lib/firebase/FireBaseCarpet';
 import { ErrorBoundary } from 'react-error-boundary';
 import { WidgetErrorFallback } from './ErrorBoundaryFallback';
+import { useLongPress } from '../../hooks/useLongPress';
 
 type ImageGridProps = {
     imageUrls: string[];
@@ -31,33 +32,13 @@ type ImageItemProps = {
 };
 
 const ImageItem = ({ imgUrl, index, isAdmin, onOpen, onDeleteClick }: ImageItemProps) => {
-    const [isPressed, setIsPressed] = useState(false);
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const startLongPress = useCallback(() => {
-        timerRef.current = setTimeout(() => {
-            setIsPressed(true);
-        }, 300);
-    }, []);
-
-    const cancelLongPress = useCallback(() => {
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-            timerRef.current = null;
-        }
-        // Delay reset so the user can still tap the revealed button
-        setTimeout(() => setIsPressed(false), 4000);
-    }, []);
+    const { handlers, isPressed } = useLongPress(300, 3000);
 
     return (
         <div
             className={`image-item${isPressed ? ' is-long-pressed' : ''}`}
             onClick={() => onOpen(index)}
-            onTouchStart={(e) => { e.stopPropagation(); startLongPress(); }}
-            onTouchEnd={cancelLongPress}
-            onTouchCancel={cancelLongPress}
-            // Prevent "Save Image" OS popup on long-press
-            onContextMenu={(e) => e.preventDefault()}
+            {...handlers}
         >
             <img src={imgUrl} alt={`Carpet view ${index + 1}`} loading="lazy" />
             {isAdmin && (

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,14 +1,19 @@
-import { useRef, useState, useCallback } from 'react';
+import { useRef, useState, useCallback, useEffect } from 'react';
 
 /**
- * Detects a long-press (~500ms hold) on touch devices.
+ * Detects a long-press hold on touch devices.
+ *
+ * @param duration        - How long (ms) the user must hold before `isPressed` becomes true. Default: 300ms.
+ * @param autoDismissDelay - If provided, `isPressed` automatically resets to false after this many ms.
+ *                          Useful for revealing hidden buttons that auto-hide if the user doesn't tap them.
  *
  * Usage:
- *   const { handlers, isPressed } = useLongPress();
+ *   const { handlers, isPressed } = useLongPress(300, 3000);
  *   <div {...handlers} className={isPressed ? 'is-long-pressed' : ''}>
  *
- * handlers.onContextMenu calls e.preventDefault() to block the browser's
- * "Save Image" / "Copy Link" popup that fires during a long touch on images.
+ * - handlers.onContextMenu calls e.preventDefault() to block the browser's
+ *   "Save Image" / "Copy Link" popup that appears during long-touch on images.
+ * - Both timers are cleaned up automatically on unmount.
  */
 
 type LongPressHandlers = {
@@ -18,46 +23,59 @@ type LongPressHandlers = {
     onContextMenu: (e: React.MouseEvent) => void;
 };
 
-type UseLongPressResult = {
+export type UseLongPressResult = {
     handlers: LongPressHandlers;
     isPressed: boolean;
 };
 
-export function useLongPress(
-    onLongPress?: () => void,
-    onRelease?: () => void,
-    duration = 500,
-): UseLongPressResult {
+export function useLongPress(duration = 300, autoDismissDelay?: number): UseLongPressResult {
     const [isPressed, setIsPressed] = useState(false);
-    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const start = useCallback(() => {
         timerRef.current = setTimeout(() => {
             setIsPressed(true);
-            onLongPress?.();
+
+            // Optionally auto-dismiss after a delay so the revealed UI
+            // doesn't stay visible indefinitely if the user doesn't tap it.
+            if (autoDismissDelay) {
+                resetTimerRef.current = setTimeout(() => setIsPressed(false), autoDismissDelay);
+            }
         }, duration);
-    }, [onLongPress, duration]);
+    }, [duration, autoDismissDelay]);
 
     const cancel = useCallback(() => {
         if (timerRef.current) {
             clearTimeout(timerRef.current);
             timerRef.current = null;
         }
+        // Also cancel the auto-dismiss so it doesn't fire after a short tap
+        if (resetTimerRef.current) {
+            clearTimeout(resetTimerRef.current);
+            resetTimerRef.current = null;
+        }
         setIsPressed(false);
-        onRelease?.();
-    }, [onRelease]);
+    }, []);
+
+    // Clear both timers when the component unmounts to prevent memory leaks
+    // and state updates on an unmounted component.
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current);
+            if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+        };
+    }, []);
 
     const handlers: LongPressHandlers = {
         onTouchStart: (e: React.TouchEvent) => {
             e.stopPropagation();
             start();
         },
-        onTouchEnd: cancel,
+        onTouchEnd:   cancel,
         onTouchCancel: cancel,
         // Prevent the browser's "Save Image" / "Copy" context menu on long-press
-        onContextMenu: (e: React.MouseEvent) => {
-            e.preventDefault();
-        },
+        onContextMenu: (e: React.MouseEvent) => e.preventDefault(),
     };
 
     return { handlers, isPressed };


### PR DESCRIPTION
Introduce `useLongPress` hook with auto-dismiss and cleanup, and integrate it into UI components for centralized long-press detection.