### PR TITLE
fix: refine long-press dismissal logic to differentiate short taps from long presses and update `CarpetDetails` auto-dismiss duration.

### DIFF
--- a/src/components/UI/CarpetDetails.tsx
+++ b/src/components/UI/CarpetDetails.tsx
@@ -24,8 +24,8 @@ export const CarpetDetails = ({ carpet, onDeleted }: CarpetDetailsProps) => {
     const isFeet = carpet.unit === 'Feet';
     const unitLabel = isFeet ? 'ft' : 'm';
 
-    // Long-press: after 300ms hold, reveals the delete icon button for 3s
-    const { handlers, isPressed } = useLongPress(300, 3000);
+    // Long-press: after 300ms hold, reveals the delete icon button for 4s
+    const { handlers, isPressed } = useLongPress(300, 4000);
 
     const handleDeleteCarpetConfirm = async () => {
         setIsDeletingCarpet(true);

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -30,31 +30,44 @@ export type UseLongPressResult = {
 
 export function useLongPress(duration = 300, autoDismissDelay?: number): UseLongPressResult {
     const [isPressed, setIsPressed] = useState(false);
-    const timerRef    = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const timerRef      = useRef<ReturnType<typeof setTimeout> | null>(null);
     const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    // Tracks whether the long-press threshold was crossed so that onTouchEnd
+    // (cancel) knows whether to hide the UI immediately (short tap) or leave
+    // it visible for the auto-dismiss timer to handle.
+    const hasFiredRef   = useRef(false);
 
     const start = useCallback(() => {
+        hasFiredRef.current = false;
         timerRef.current = setTimeout(() => {
+            hasFiredRef.current = true;
             setIsPressed(true);
 
             // Optionally auto-dismiss after a delay so the revealed UI
             // doesn't stay visible indefinitely if the user doesn't tap it.
             if (autoDismissDelay) {
-                resetTimerRef.current = setTimeout(() => setIsPressed(false), autoDismissDelay);
+                resetTimerRef.current = setTimeout(() => {
+                    hasFiredRef.current = false;
+                    setIsPressed(false);
+                }, autoDismissDelay);
             }
         }, duration);
     }, [duration, autoDismissDelay]);
 
     const cancel = useCallback(() => {
+        // Always clear a still-pending long-press timer (short tap / early release)
         if (timerRef.current) {
             clearTimeout(timerRef.current);
             timerRef.current = null;
         }
-        // Also cancel the auto-dismiss so it doesn't fire after a short tap
-        if (resetTimerRef.current) {
-            clearTimeout(resetTimerRef.current);
-            resetTimerRef.current = null;
+
+        if (hasFiredRef.current) {
+            // Long-press already activated — lifting the finger should NOT hide
+            // the revealed UI. The auto-dismiss timer owns that transition.
+            return;
         }
+
+        // Short tap: long-press never fired, so nothing was revealed — stay hidden.
         setIsPressed(false);
     }, []);
 


### PR DESCRIPTION
fix: refine long-press dismissal logic to differentiate short taps from long presses and update `CarpetDetails` auto-dismiss duration.